### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/backend/blueprints/student_blueprint.py
+++ b/backend/blueprints/student_blueprint.py
@@ -95,7 +95,7 @@ class StudentBlueprint:
             
         except ValueError as e:
             logger.warning(f"⚠️ Validation error: {str(e)}")
-            return jsonify({'error': str(e)}), 400
+            return jsonify({'error': 'Invalid input.'}), 400
         except Exception as e:
             logger.error(f"❌ Error in create_student endpoint: {str(e)}")
             return jsonify({'error': 'Failed to create student'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/IronL442/Gewerbe-EE/security/code-scanning/3](https://github.com/IronL442/Gewerbe-EE/security/code-scanning/3)

The best way to fix this issue is to avoid exposing the raw exception message (`str(e)`) in the HTTP response to the user. Instead, provide a generic, user-friendly error message (e.g., `"Invalid input."` or a more specific static message), while logging the detailed exception message on the server for debugging and support purposes.

Specifically:
- In the `except ValueError as e` block under `create_student`, change the response from `{'error': str(e)}` to a generic, non-sensitive error message such as `{'error': 'Invalid input.'}`.
- Continue logging the actual exception as is to your server logs.
- No external dependencies are needed; the existing `logger` already logs the details.

Only edit lines 96–98.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
