### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/blueprints/student_blueprint.py
+++ b/backend/blueprints/student_blueprint.py
@@ -59,7 +59,7 @@ class StudentBlueprint:
             
         except ValueError as e:
             logger.warning(f"⚠️ Validation error: {str(e)}")
-            return jsonify({'error': str(e)}), 400
+            return jsonify({'error': 'Validation error'}), 400
         except Exception as e:
             logger.error(f"❌ Error in create_customer endpoint: {str(e)}")
             return jsonify({'error': 'Failed to create customer'}), 500


### PR DESCRIPTION
Potential fix for [https://github.com/IronL442/Gewerbe-EE/security/code-scanning/2](https://github.com/IronL442/Gewerbe-EE/security/code-scanning/2)

To address this, do not expose the actual exception (`str(e)`) in API responses. Instead, provide a generic message to the client indicating a validation error occurred, such as `'Validation error'`, and log the specific details on the server for diagnostics.

- Change line 62 in `create_customer` so that the error message returned does not use `str(e)` but is a fixed, generic user-facing message (such as `'Validation error'`). Keep the logging statement as-is so developers can see details in the log.
- As you can only make changes in the shown code, only edit the specific return statement in the `except ValueError` block of `create_customer`.

No additional imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
